### PR TITLE
Support for generating tests for Draft 2019-09 and 2020-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Support for generating tests for Draft 2019-09 and 2020-12
+
 ## 0.3.0 (2020-06-29)
 
 * Ignore tests accepts regular expressions

--- a/proc_macro/src/lib.rs
+++ b/proc_macro/src/lib.rs
@@ -96,7 +96,11 @@ pub fn json_schema_test_suite(attr: TokenStream, item: TokenStream) -> TokenStre
 
     let setup_mockito_mocks_token_stream = mockito_mocks::setup(&proc_macro_attributes.json_schema_test_suite_path);
 
-    let mod_name = format_ident!("{}_{}", original_function_ident, proc_macro_attributes.draft_folder);
+    let mod_name = format_ident!(
+        "{}_{}",
+        original_function_ident,
+        proc_macro_attributes.draft_folder.replace("-", "_")
+    );
 
     let output = quote! {
         #item_fn


### PR DESCRIPTION
Hi!

With the current version tests complain about `draft2019-09`:

```rust
#[json_schema_test_suite("tests/suite", "draft2019-09", {})]
fn test_draft(_server_address: &str, test_case: TestCase) {
    ...
}
```

```
message: `"test_draft_draft2019-09"` is not a valid identifier
```

